### PR TITLE
fix 02_testing multiClasses write out_filename_Stats.txt format error

### DIFF
--- a/DeepPATH_code/02_testing/multiClasses/inception/nc_inception_eval.py
+++ b/DeepPATH_code/02_testing/multiClasses/inception/nc_inception_eval.py
@@ -280,7 +280,8 @@ def _eval_once(saver, summary_writer, summary_op, max_percent_op, all_filenames,
           for kk in range(len(out_filenames)):
               myfile.write(out_filenames[kk].decode('UTF-8') + "\t")
               myfile.write(str(labels[kk]) + "\t")
-              myfile.write(" ".join(str(max_percent[kk]).splitlines()) + "\t")        
+              myfile.write(" ".join(str(max_percent[kk]).splitlines()) + "\t") 
+              myfile.write('\n')       
 
 
 


### PR DESCRIPTION
I think in file 
> DeepPATH\DeepPATH_code\02_testing\multiClasses\inception\nc_inception_eval.py,

 at line 284, shoud write "\n" to the out_filename_Stats.txt, otherwise the generate file only has one line. 


If all information is in one line, 0h_ROC_MultiOutput_BootStrap.py won't work properly.

