### PR TITLE
fix typo

### DIFF
--- a/DeepPATH_code/example_TCGA_lung/checkpoints/README.md
+++ b/DeepPATH_code/example_TCGA_lung/checkpoints/README.md
@@ -1,4 +1,4 @@
-The checkpoints different runs using 2168 WSI (Lung) from the TCGA are saved there:
+The checkpoints different runs using 2166 WSI (Lung) from the TCGA are saved there:
 
 `run1a_3D_classifier` was run using batch size of 400; checkpoints at 69k
 (AUC of validation for Normal/LUAD/LUAD: 0.9997/0.970/0.967; for test set: 0.991/0.949/0.942)


### PR DESCRIPTION
There are only 2167 wsi's. See the size of the manifest (2168, minus the header =2167) .
After running your code i only got 2166 (meaning, somehow one is not used).